### PR TITLE
Create shaderCompiler.py

### DIFF
--- a/shaderCompiler.py
+++ b/shaderCompiler.py
@@ -8,7 +8,7 @@ def compileShaders(glslangValidatorPath = None):
         print("Shaders found:")
         for shader in os.listdir("src\\shaders\\"):
             if shader.endswith(".vert") or shader.endswith(".frag"):
-                os.system(f"{glslangValidatorPath} -V -Os -o ./src\\shaders\\" + shader[:-5] + ".spv ./src\\shaders\\" + shader)
+                os.system(f"{glslangValidatorPath} -V -Os -o ./src\\shaders\\" + shader + ".spv ./src\\shaders\\" + shader)
     else:
         print("Shaders not found, make sure this script is in the root of the project, or that {project_root}\\src\\shaders\\ or {project_root}\\shaders\\ exists.")
 

--- a/shaderCompiler.py
+++ b/shaderCompiler.py
@@ -1,0 +1,21 @@
+import platform
+import os
+
+def compileShaders(glslangValidatorPath = None):
+    if not glslangValidatorPath:
+        glslangValidatorPath = "glslangValidator"
+    if os.path.isdir("./src\\shaders\\"):
+        print("Shaders found:")
+        for shader in os.listdir("src\\shaders\\"):
+            if shader.endswith(".vert") or shader.endswith(".frag"):
+                os.system(f"{glslangValidatorPath} -V -o ./src\\shaders\\" + shader[:-5] + ".spv ./src\\shaders\\" + shader)
+    else:
+        print("Shaders not found, make sure this script is in the root of the project, or that {project_root}\\src\\shaders\\ or {project_root}\\shaders\\ exists.")
+
+if "VULKAN_sSDK" in os.environ or "VK_sSDK_PATH" in os.environ or os.path.exists("/usr/bin/glslangValidator"):
+    print("Vulkan SDK found")
+    compileShaders()
+else:
+    print("Vulkan SDK/glslangValidator not found")
+    glslV_Path = input("Enter the full path to your glslangValidator binary location (I.E. `C:\\VulkanSDK\\1.2.198.1\\Bin\\glslandValidator.exe` or `/usr/bin/glslangValidator): ")
+    compileShaders(glslV_Path)

--- a/shaderCompiler.py
+++ b/shaderCompiler.py
@@ -8,11 +8,11 @@ def compileShaders(glslangValidatorPath = None):
         print("Shaders found:")
         for shader in os.listdir("src\\shaders\\"):
             if shader.endswith(".vert") or shader.endswith(".frag"):
-                os.system(f"{glslangValidatorPath} -V -o ./src\\shaders\\" + shader[:-5] + ".spv ./src\\shaders\\" + shader)
+                os.system(f"{glslangValidatorPath} -V -Os -o ./src\\shaders\\" + shader[:-5] + ".spv ./src\\shaders\\" + shader)
     else:
         print("Shaders not found, make sure this script is in the root of the project, or that {project_root}\\src\\shaders\\ or {project_root}\\shaders\\ exists.")
 
-if "VULKAN_sSDK" in os.environ or "VK_sSDK_PATH" in os.environ or os.path.exists("/usr/bin/glslangValidator"):
+if "VULKAN_SDK" in os.environ or "VK_SDK_PATH" in os.environ or os.path.exists("/usr/bin/glslangValidator"):
     print("Vulkan SDK found")
     compileShaders()
 else:


### PR DESCRIPTION
Auto Compile shaders, with the ability to take a custom location for glslangValidator if in custom install/VK_SDK_PATH or VULKAN_SDK is not set, or the binary is otherwise not on your PATH.